### PR TITLE
Fix card layout alignment in EmployeeDashboard

### DIFF
--- a/src/pages/EmployeeDashboard.tsx
+++ b/src/pages/EmployeeDashboard.tsx
@@ -126,16 +126,16 @@ export default function EmployeeDashboard() {
                 key={card.id}
                 className={cn(
                   "flex w-full min-w-[200px] sm:min-w-[251px] h-[100px] sm:h-[116px]",
-                  "px-3 sm:px-4 justify-center items-center gap-2 flex-shrink-0",
+                  "px-3 sm:px-4 justify-center items-center flex-shrink-0",
                   "rounded-[10px] border-b-[6px] border-[#4766E5] bg-white",
                   "shadow-[0px_2px_4px_0px_rgba(0,0,0,0.10),0px_4px_8px_0px_rgba(0,0,0,0.05)]",
                   "cursor-pointer transition-transform hover:scale-[1.02] hover:shadow-md",
                 )}
               >
-                <div className="flex w-[35px] sm:w-[41px] flex-col items-start flex-shrink-0">
-                  {card.icon}
-                </div>
-                <div className="flex justify-start items-center flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <div className="flex w-[35px] sm:w-[41px] flex-col items-center justify-center flex-shrink-0">
+                    {card.icon}
+                  </div>
                   <h3 className="text-[#283C50] font-inter font-bold text-sm sm:text-base leading-[20px] sm:leading-[25.6px]">
                     {card.title}
                   </h3>


### PR DESCRIPTION
Updated the card layout structure in EmployeeDashboard component:
- Removed gap-2 class from the main card container
- Restructured the inner layout to use a flex container with gap-2 for icon and title
- Changed icon container alignment from items-start to items-center justify-center
- Removed the separate flex-1 container around the title
- Title now sits directly in the flex container with the icon

These changes improve the visual alignment and spacing of the dashboard cards.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d083cfb580b4c7aa91f59181f944153/stellar-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d083cfb580b4c7aa91f59181f944153</projectId>-->