### PR TITLE
Replace ChevronRight import with custom icon

### DIFF
--- a/src/pages/EmployeeDashboard.tsx
+++ b/src/pages/EmployeeDashboard.tsx
@@ -102,7 +102,7 @@ export default function EmployeeDashboard() {
               Liberty Highrise PVT Ltd
             </span>
             <div className="hidden sm:block">
-              <ChevronRight className="w-1 h-[7px] text-[#7C8796] flex-shrink-0" />
+              <ChevronRightIcon />
             </div>
             <span className="text-[#222] font-inter text-xs sm:text-[13px] font-normal leading-[16px] sm:leading-[20.8px] hidden sm:block">
               All Branch

--- a/src/pages/EmployeeDashboard.tsx
+++ b/src/pages/EmployeeDashboard.tsx
@@ -1,10 +1,28 @@
-import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import AttendanceSummary from "@/components/AttendanceSummary";
 import PerformanceMeter from "@/components/PerformanceMeter";
 import WagesSummary from "@/components/WagesSummary";
 import LeaveBalance from "@/components/LeaveBalance";
 import UpcomingHolidays from "@/components/UpcomingHolidays";
+
+// Custom ChevronRight Icon to match Overview page
+const ChevronRightIcon = () => (
+  <svg
+    width="6"
+    height="9"
+    viewBox="0 0 6 9"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="w-1 h-[7px] flex-shrink-0"
+  >
+    <path
+      d="M1.00391 7.595L5.00391 4.095L1.00391 0.595001"
+      stroke="#7C8796"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export default function EmployeeDashboard() {
   const cardData = [


### PR DESCRIPTION
Removed the ChevronRight import from lucide-react and replaced it with a custom ChevronRightIcon component in the EmployeeDashboard page. The custom icon maintains the same visual appearance and styling (w-1 h-[7px] with #7C8796 color) but is now defined as an inline SVG component to match the Overview page implementation.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e93ebaa72ff143369d6b6080a51213a6/pulse-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e93ebaa72ff143369d6b6080a51213a6</projectId>-->