### PR TITLE
Remove "Work From" label from attendance summary

### DIFF
--- a/src/components/AttendanceSummary.tsx
+++ b/src/components/AttendanceSummary.tsx
@@ -126,9 +126,6 @@ export default function AttendanceSummary() {
                     <span className="text-gray-800 font-semibold ml-1">21</span>
                   </span>
                 </div>
-                <div className="text-right">
-                  <span className="text-gray-500 text-xs">Work From</span>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Removes the "Work From" text label and its container div from the AttendanceSummary component. This eliminates the right-aligned gray text that was previously displayed in the attendance summary interface.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`

🔗 [Edit in Builder.io](https://builder.io/app/projects/756e54dc0a3444bdba513fdfd7679519/swoosh-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>756e54dc0a3444bdba513fdfd7679519</projectId>-->