### PR TITLE
Builder.io: Auto-collapse sidebar on chat page

### DIFF
--- a/src/hooks/useSidebar.tsx
+++ b/src/hooks/useSidebar.tsx
@@ -20,6 +20,16 @@ const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const location = useLocation();
+
+  // Auto-collapse sidebar on chat page, expand on other pages
+  useEffect(() => {
+    if (location.pathname === "/chats") {
+      setIsExpanded(false);
+    } else {
+      setIsExpanded(true);
+    }
+  }, [location.pathname]);
 
   // Auto-expand and close mobile overlay on resize
   useEffect(() => {
@@ -27,8 +37,6 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
       if (window.innerWidth >= 768) {
         setIsMobileOpen(false);
       }
-      // Keep sidebar expanded on all screen sizes
-      setIsExpanded(true);
     };
 
     handleResize();

--- a/src/hooks/useSidebar.tsx
+++ b/src/hooks/useSidebar.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   ReactNode,
 } from "react";
+import { useLocation } from "react-router-dom";
 
 interface SidebarContextType {
   isExpanded: boolean;


### PR DESCRIPTION
Add automatic sidebar state management based on current route.

Changes:
- Import useLocation from react-router-dom
- Add useEffect to auto-collapse sidebar when on /chats page
- Auto-expand sidebar on all other pages
- Remove forced expansion behavior on window resize

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f259fdcbe37a42db88ffcf2f993f60dd/mystic-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f259fdcbe37a42db88ffcf2f993f60dd</projectId>-->
<!--<branchName>mystic-zone</branchName>-->