### PR TITLE
Increase height and font sizes in EmployeeWorkingHourTrendsCard

### DIFF
--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -385,13 +385,13 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           </h3>
         </div>
         <div className="flex flex-col items-end text-right">
-          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold">
+          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold leading-none">
             Total Hour :{" "}
             <span className="text-[11px] sm:text-[12px] lg:text-[13px]">
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-5">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-6">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -385,13 +385,11 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           </h3>
         </div>
         <div className="flex flex-col items-end text-right">
-          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold">
-            Total Hour :{" "}
-            <span className="text-[11px] sm:text-[12px] lg:text-[13px]">
-              208
-            </span>
-          </div>
           <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal">
+            Total Hour :{" "}
+            <span className="text-[9px] sm:text-[10px] lg:text-[11px] font-bold">
+              208
+            </span>{" "}
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-6">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-8">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -377,7 +377,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       )}
     >
       {/* Header - Made more compact */}
-      <div className="flex items-center justify-between px-2 py-0.5 sm:px-3 sm:py-1 lg:px-4 lg:py-1 border-b border-gray-100 flex-shrink-0">
+      <div className="flex items-center justify-between px-2 pt-0.5 pb-0 sm:px-3 sm:pt-1 sm:pb-0 lg:px-4 lg:pt-1 lg:pb-0 border-b border-gray-100 flex-shrink-0">
         <div className="flex flex-col">
           <h3 className="text-[#1a1a1a] font-inter text-[14px] font-bold leading-tight">
             Employee Working Hour Trends{" "}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -385,11 +385,13 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           </h3>
         </div>
         <div className="flex flex-col items-end text-right">
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal">
+          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold">
             Total Hour :{" "}
-            <span className="text-[9px] sm:text-[10px] lg:text-[11px] font-bold">
+            <span className="text-[11px] sm:text-[12px] lg:text-[13px]">
               208
-            </span>{" "}
+            </span>
+          </div>
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -401,7 +401,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       {/* Chart Content - Expanded to take more space */}
       <div className="flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-1 lg:px-4 lg:py-1 flex-1">
         {/* Chart - Increased height */}
-        <div className="flex-1" style={{ minHeight: "65px", height: "65px" }}>
+        <div className="flex-1" style={{ minHeight: "80px", height: "80px" }}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -373,7 +373,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       className={cn(
         "flex flex-col bg-white rounded-[10px] border-b-[6px] border-[#4766E5]",
         "shadow-[0px_2px_4px_0px_rgba(0,0,0,0.10),0px_4px_8px_0px_rgba(0,0,0,0.05)]",
-        "w-full min-w-0 h-[90px] sm:h-[105px] lg:h-[120px]",
+        "w-full min-w-0 h-[110px] sm:h-[125px] lg:h-[140px]",
       )}
     >
       {/* Header - Made more compact */}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-8">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-12">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -405,7 +405,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}
-              margin={{ top: 15, right: 2, left: 15, bottom: 10 }}
+              margin={{ top: 25, right: 2, left: 15, bottom: 10 }}
             >
               <CartesianGrid
                 strokeDasharray="3 3"

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-1">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-2">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-3">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-5">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-1">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -415,7 +415,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               />
               <XAxis
                 dataKey="day"
-                tick={{ fontSize: 7, fill: "#1a1a1a", fontWeight: "bold" }}
+                tick={{ fontSize: 10, fill: "#1a1a1a", fontWeight: "bold" }}
                 axisLine={{ stroke: "#E5E7EB" }}
                 tickLine={false}
                 height={12}
@@ -423,7 +423,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               <YAxis
                 domain={[0, 12]}
                 tickFormatter={(value) => `${value}h`}
-                tick={{ fontSize: 7, fill: "#1a1a1a", fontWeight: "bold" }}
+                tick={{ fontSize: 10, fill: "#1a1a1a", fontWeight: "bold" }}
                 axisLine={false}
                 tickLine={false}
                 width={20}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -385,13 +385,13 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           </h3>
         </div>
         <div className="flex flex-col items-end text-right">
-          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold leading-none">
+          <div className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold">
             Total Hour :{" "}
             <span className="text-[11px] sm:text-[12px] lg:text-[13px]">
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-8">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-2">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal -mt-3">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -401,7 +401,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       {/* Chart Content - Expanded to take more space */}
       <div className="flex items-center gap-2 px-2 py-1 sm:px-3 sm:py-1 lg:px-4 lg:py-1 flex-1">
         {/* Chart - Increased height */}
-        <div className="flex-1" style={{ minHeight: "80px", height: "80px" }}>
+        <div className="flex-1" style={{ minHeight: "100px", height: "100px" }}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -405,7 +405,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}
-              margin={{ top: 25, right: 2, left: 15, bottom: 10 }}
+              margin={{ top: 35, right: 2, left: 15, bottom: 10 }}
             >
               <CartesianGrid
                 strokeDasharray="3 3"

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -428,8 +428,8 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
                 tickLine={false}
                 width={20}
                 interval={0}
-                tickCount={5}
-                ticks={[0, 4, 8, 12]}
+                tickCount={3}
+                ticks={[0, 6, 12]}
               />
               <Tooltip
                 formatter={(value) => [`${value}h`, ""]}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -405,7 +405,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}
-              margin={{ top: 2, right: 2, left: 15, bottom: 10 }}
+              margin={{ top: 8, right: 2, left: 15, bottom: 10 }}
             >
               <CartesianGrid
                 strokeDasharray="3 3"

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -405,7 +405,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={workingHourData}
-              margin={{ top: 8, right: 2, left: 15, bottom: 10 }}
+              margin={{ top: 15, right: 2, left: 15, bottom: 10 }}
             >
               <CartesianGrid
                 strokeDasharray="3 3"

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -373,7 +373,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       className={cn(
         "flex flex-col bg-white rounded-[10px] border-b-[6px] border-[#4766E5]",
         "shadow-[0px_2px_4px_0px_rgba(0,0,0,0.10),0px_4px_8px_0px_rgba(0,0,0,0.05)]",
-        "w-full min-w-0 h-[110px] sm:h-[125px] lg:h-[140px]",
+        "w-full min-w-0 h-[130px] sm:h-[145px] lg:h-[160px]",
       )}
     >
       {/* Header - Made more compact */}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -391,7 +391,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
               208
             </span>
           </div>
-          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-12">
+          <div className="text-[#1a1a1a] font-inter text-[8px] sm:text-[9px] lg:text-[10px] font-normal leading-none -mt-8">
             Worked : <span className="text-[#22C55E] font-semibold">160</span>{" "}
             OT : <span className="text-[#3B82F6] font-semibold">14</span> Hrs
           </div>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -379,7 +379,7 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
       {/* Header - Made more compact */}
       <div className="flex items-center justify-between px-2 py-0.5 sm:px-3 sm:py-1 lg:px-4 lg:py-1 border-b border-gray-100 flex-shrink-0">
         <div className="flex flex-col">
-          <h3 className="text-[#1a1a1a] font-inter text-[10px] sm:text-[11px] lg:text-[12px] font-bold leading-tight">
+          <h3 className="text-[#1a1a1a] font-inter text-[14px] font-bold leading-tight">
             Employee Working Hour Trends{" "}
             <span className="text-[#4766E5] font-bold">- Sept 2024</span>
           </h3>

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -428,8 +428,8 @@ const EmployeeWorkingHourTrendsCard: React.FC = () => {
                 tickLine={false}
                 width={20}
                 interval={0}
-                tickCount={3}
-                ticks={[0, 6, 12]}
+                tickCount={5}
+                ticks={[0, 4, 8, 12]}
               />
               <Tooltip
                 formatter={(value) => [`${value}h`, ""]}


### PR DESCRIPTION
Increases the overall height of the EmployeeWorkingHourTrendsCard component and adjusts related sizing:

- Increases card height from 90px/105px/120px to 130px/145px/160px across breakpoints
- Adjusts header padding to remove bottom padding while keeping top padding
- Increases title font size from responsive 10px/11px/12px to fixed 14px
- Expands chart area height from 65px to 100px
- Increases chart top margin from 2px to 35px
- Increases X-axis and Y-axis tick font size from 7px to 10px

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/faf3df9bc77f46e6982d1fc5e460be0f/neon-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>faf3df9bc77f46e6982d1fc5e460be0f</projectId>-->
<!--<branchName>neon-space</branchName>-->