### PR TITLE
Add hideHeader prop to chat components and redesign layout

### DIFF
--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2535,82 +2535,77 @@ const ChatContactsList: React.FC<{
   return (
     <div className="flex flex-col h-full bg-white border-r border-gray-200">
       {/* Header */}
-      <div className="p-4 border-b border-gray-200">
-        {/* Title and Action Buttons */}
-        <div className="flex items-center justify-between mb-3">
-          <h1 className="text-xl font-semibold text-gray-900">Chats</h1>
-          <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-            <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <MoreVertical className="h-4 w-4 text-gray-600" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-80 p-4" align="end">
-              {/* Filter Tabs */}
-              <div className="space-y-4">
-                <div className="flex gap-2 flex-wrap">
-                  {filterTabs.map((filter) => {
-                    const count = getFilterCount(filter);
-                    return (
-                      <button
-                        key={filter}
-                        onClick={() => {
-                          onFilterChange(filter);
-                          setIsPopoverOpen(false);
-                        }}
-                        className={cn(
-                          "px-4 py-2 rounded-full text-sm font-medium transition-colors flex items-center gap-2",
-                          selectedFilter === filter
-                            ? "bg-blue-500 text-white"
-                            : "bg-gray-100 text-gray-700 hover:bg-gray-200",
-                        )}
-                      >
-                        <span>{filter}</span>
-                        <Badge
-                          className={cn(
-                            "text-xs",
-                            selectedFilter === filter
-                              ? "bg-white/20 text-white"
-                              : "bg-blue-500 text-white",
-                          )}
-                        >
-                          {count}
-                        </Badge>
-                      </button>
-                    );
-                  })}
-                </div>
-
-                {/* Task Summary Cards */}
-                <div className="grid grid-cols-2 gap-3">
-                  {taskSummaries.map((task) => (
-                    <div
-                      key={task.id}
-                      className="bg-gray-100 rounded-2xl p-4 text-center cursor-pointer hover:bg-gray-200 transition-colors"
-                    >
-                      <div className="text-2xl font-bold text-blue-500 mb-1">
-                        {task.count}
-                      </div>
-                      <div className="text-xs font-medium text-gray-800 leading-tight">
-                        {task.title}
-                      </div>
-                    </div>
-                  ))}
+      <div className="p-4 border-b border-gray-200 bg-white">
+        {/* Task Summary Cards Row */}
+        <div className="flex justify-end mb-3">
+          <div className="flex gap-3">
+            {taskSummaries.map((task) => (
+              <div
+                key={task.id}
+                className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
+                style={{ minWidth: "70px" }}
+              >
+                <div className="text-center">
+                  <div className="text-lg font-bold text-gray-900 mb-1">
+                    {task.count}
+                  </div>
+                  <div className="text-xs text-gray-600 leading-tight">
+                    {task.title}
+                  </div>
                 </div>
               </div>
-            </PopoverContent>
-          </Popover>
+            ))}
+          </div>
         </div>
 
-        {/* Search */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <Input
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search or start a new chat"
-            className="pl-10 bg-gray-50 border-gray-200"
-          />
+        {/* Main Header Row: Title, Search, and Filters */}
+        <div className="flex items-center gap-4">
+          {/* Chats Title */}
+          <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
+            Chats
+          </h1>
+
+          {/* Search Bar */}
+          <div className="relative flex-shrink-0" style={{ width: "200px" }}>
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Search or start a new chat"
+              className="pl-10 bg-gray-50 border-gray-200 h-9"
+            />
+          </div>
+
+          {/* Filter Buttons */}
+          <div className="flex gap-2 flex-1">
+            {filterTabs.map((filter) => {
+              const count = getFilterCount(filter);
+              return (
+                <button
+                  key={filter}
+                  onClick={() => onFilterChange(filter)}
+                  className={cn(
+                    "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
+                    selectedFilter === filter
+                      ? "bg-blue-500 text-white"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200",
+                  )}
+                >
+                  <span>{filter}</span>
+                  <span
+                    className={cn(
+                      "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                      selectedFilter === filter
+                        ? "bg-white/20 text-white"
+                        : "bg-blue-500 text-white",
+                    )}
+                  >
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3473,29 +3473,7 @@ const Chats: React.FC = () => {
       >
         {/* Full Width Controls Section */}
         <div className="w-full p-4 border-b border-gray-200 bg-white">
-          {/* Task Summary Cards Row */}
-          <div className="flex justify-end mb-3">
-            <div className="flex gap-3">
-              {taskSummaries.map((task) => (
-                <div
-                  key={task.id}
-                  className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
-                  style={{ minWidth: "70px" }}
-                >
-                  <div className="text-center">
-                    <div className="text-lg font-bold text-gray-900 mb-1">
-                      {task.count}
-                    </div>
-                    <div className="text-xs text-gray-600 leading-tight">
-                      {task.title}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Main Row: Title, Search, and Filters */}
+          {/* Single Row: Title, Search, Filters, and Task Cards */}
           <div className="flex items-center gap-4">
             {/* Chats Title */}
             <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
@@ -3503,7 +3481,7 @@ const Chats: React.FC = () => {
             </h1>
 
             {/* Search Bar */}
-            <div className="relative flex-shrink-0" style={{ width: "200px" }}>
+            <div className="relative flex-shrink-0" style={{ width: "180px" }}>
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <Input
                 value={searchQuery}
@@ -3542,6 +3520,26 @@ const Chats: React.FC = () => {
                   </button>
                 );
               })}
+            </div>
+
+            {/* Task Summary Cards */}
+            <div className="flex gap-2 flex-shrink-0">
+              {taskSummaries.map((task) => (
+                <div
+                  key={task.id}
+                  className="bg-white rounded-lg p-2 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
+                  style={{ minWidth: "60px" }}
+                >
+                  <div className="text-center">
+                    <div className="text-sm font-bold text-gray-900 mb-0.5">
+                      {task.count}
+                    </div>
+                    <div className="text-xs text-gray-600 leading-tight">
+                      {task.title}
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3435,31 +3435,148 @@ const Chats: React.FC = () => {
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}
       <div
-        className="hidden lg:flex h-full bg-white"
+        className="hidden lg:flex flex-col h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Left Panel - Chat Contacts */}
-        <div className="w-1/3 min-w-[300px] max-w-[400px]">
-          <ChatContactsList
-            chatItems={filteredChats}
-            selectedChat={selectedChat}
-            onChatSelect={setSelectedChat}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            selectedFilter={selectedFilter}
-            onFilterChange={setSelectedFilter}
-          />
+        {/* Full Width Chat Header - Only show when chat is selected */}
+        {selectedChat && (
+          <div className="w-full border-b border-gray-200 bg-white">
+            <div className="flex items-center gap-3 p-4">
+              <Avatar className="h-10 w-10">
+                <AvatarImage
+                  src={selectedChat.avatar}
+                  alt={selectedChat.name}
+                />
+                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+                  {selectedChat.name
+                    .split(" ")
+                    .map((n) => n[0])
+                    .join("")
+                    .slice(0, 2)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="flex-1">
+                <h2 className="font-semibold text-gray-900">
+                  {selectedChat.name}
+                </h2>
+                <p className="text-sm text-gray-500">Online</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Phone className="h-4 w-4 text-gray-600" />
+                </Button>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Full Width Controls Section */}
+        <div className="w-full p-4 border-b border-gray-200 bg-white">
+          {/* Task Summary Cards Row */}
+          <div className="flex justify-end mb-3">
+            <div className="flex gap-3">
+              {taskSummaries.map((task) => (
+                <div
+                  key={task.id}
+                  className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
+                  style={{ minWidth: "70px" }}
+                >
+                  <div className="text-center">
+                    <div className="text-lg font-bold text-gray-900 mb-1">
+                      {task.count}
+                    </div>
+                    <div className="text-xs text-gray-600 leading-tight">
+                      {task.title}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Main Row: Title, Search, and Filters */}
+          <div className="flex items-center gap-4">
+            {/* Chats Title */}
+            <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
+              Chats
+            </h1>
+
+            {/* Search Bar */}
+            <div className="relative flex-shrink-0" style={{ width: "200px" }}>
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search or start a new chat"
+                className="pl-10 bg-gray-50 border-gray-200 h-9"
+              />
+            </div>
+
+            {/* Filter Buttons */}
+            <div className="flex gap-2 flex-1">
+              {filterTabs.map((filter) => {
+                const count = getFilterCount(filter);
+                return (
+                  <button
+                    key={filter}
+                    onClick={() => setSelectedFilter(filter)}
+                    className={cn(
+                      "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
+                      selectedFilter === filter
+                        ? "bg-blue-500 text-white"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200",
+                    )}
+                  >
+                    <span>{filter}</span>
+                    <span
+                      className={cn(
+                        "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                        selectedFilter === filter
+                          ? "bg-white/20 text-white"
+                          : "bg-blue-500 text-white",
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
         </div>
 
-        {/* Right Panel - Chat Conversation */}
-        <ChatConversation
-          selectedChat={selectedChat}
-          messages={currentMessages}
-          messageText={messageText}
-          onMessageChange={setMessageText}
-          onSendMessage={handleSendMessage}
-          onOpenActions={() => setIsActionDrawerOpen(true)}
-        />
+        {/* Main Content Area */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left Panel - Chat Contacts */}
+          <div className="w-1/3 min-w-[300px] max-w-[400px]">
+            <ChatContactsList
+              chatItems={filteredChats}
+              selectedChat={selectedChat}
+              onChatSelect={setSelectedChat}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              selectedFilter={selectedFilter}
+              onFilterChange={setSelectedFilter}
+              hideHeader={true}
+            />
+          </div>
+
+          {/* Right Panel - Chat Conversation */}
+          <ChatConversation
+            selectedChat={selectedChat}
+            messages={currentMessages}
+            messageText={messageText}
+            onMessageChange={setMessageText}
+            onSendMessage={handleSendMessage}
+            onOpenActions={() => setIsActionDrawerOpen(true)}
+            hideHeader={true}
+          />
+        </div>
       </div>
 
       {/* MOBILE/TABLET LAYOUT - Original Design with Task Cards & Filters */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3471,43 +3471,6 @@ const Chats: React.FC = () => {
         className="hidden lg:flex flex-col h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Full Width Chat Header - Only show when chat is selected */}
-        {selectedChat && (
-          <div className="w-full border-b border-gray-200 bg-white">
-            <div className="flex items-center gap-3 p-4">
-              <Avatar className="h-10 w-10">
-                <AvatarImage
-                  src={selectedChat.avatar}
-                  alt={selectedChat.name}
-                />
-                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-                  {selectedChat.name
-                    .split(" ")
-                    .map((n) => n[0])
-                    .join("")
-                    .slice(0, 2)}
-                </AvatarFallback>
-              </Avatar>
-
-              <div className="flex-1">
-                <h2 className="font-semibold text-gray-900">
-                  {selectedChat.name}
-                </h2>
-                <p className="text-sm text-gray-500">Online</p>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <Phone className="h-4 w-4 text-gray-600" />
-                </Button>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
         {/* Full Width Controls Section */}
         <div className="w-full p-4 border-b border-gray-200 bg-white">
           {/* Task Summary Cards Row */}
@@ -3607,7 +3570,6 @@ const Chats: React.FC = () => {
             onMessageChange={setMessageText}
             onSendMessage={handleSendMessage}
             onOpenActions={() => setIsActionDrawerOpen(true)}
-            hideHeader={true}
           />
         </div>
       </div>

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2603,17 +2603,15 @@ const ChatContactsList: React.FC<{
         </div>
 
         {/* Search */}
-        {!hideSearch && (
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search or start a new chat"
-              className="pl-10 bg-gray-50 border-gray-200"
-            />
-          </div>
-        )}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search or start a new chat"
+            className="pl-10 bg-gray-50 border-gray-200"
+          />
+        </div>
       </div>
 
       {/* Chat List */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2605,15 +2605,17 @@ const ChatContactsList: React.FC<{
         </div>
 
         {/* Search */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <Input
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search or start a new chat"
-            className="pl-10 bg-gray-50 border-gray-200"
-          />
-        </div>
+        {!hideSearch && (
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Search or start a new chat"
+              className="pl-10 bg-gray-50 border-gray-200"
+            />
+          </div>
+        )}
       </div>
 
       {/* Chat List */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2689,7 +2689,6 @@ const ChatConversation: React.FC<{
   onMessageChange: (text: string) => void;
   onSendMessage: () => void;
   onOpenActions: () => void;
-  hideHeader?: boolean;
 }> = ({
   selectedChat,
   messages,
@@ -2697,7 +2696,6 @@ const ChatConversation: React.FC<{
   onMessageChange,
   onSendMessage,
   onOpenActions,
-  hideHeader = false,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3440,31 +3440,72 @@ const Chats: React.FC = () => {
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}
       <div
-        className="hidden lg:flex h-full bg-white"
+        className="hidden lg:flex flex-col h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Left Panel - Chat Contacts */}
-        <div className="w-1/3 min-w-[300px] max-w-[400px]">
-          <ChatContactsList
-            chatItems={filteredChats}
+        {/* Full Width Chat Header - Only show when chat is selected */}
+        {selectedChat && (
+          <div className="w-full border-b border-gray-200 bg-white">
+            <div className="flex items-center gap-3 p-4">
+              <Avatar className="h-10 w-10">
+                <AvatarImage
+                  src={selectedChat.avatar}
+                  alt={selectedChat.name}
+                />
+                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+                  {selectedChat.name
+                    .split(" ")
+                    .map((n) => n[0])
+                    .join("")
+                    .slice(0, 2)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="flex-1">
+                <h2 className="font-semibold text-gray-900">
+                  {selectedChat.name}
+                </h2>
+                <p className="text-sm text-gray-500">Online</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Phone className="h-4 w-4 text-gray-600" />
+                </Button>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Main Content Area */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left Panel - Chat Contacts */}
+          <div className="w-1/3 min-w-[300px] max-w-[400px]">
+            <ChatContactsList
+              chatItems={filteredChats}
+              selectedChat={selectedChat}
+              onChatSelect={setSelectedChat}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              selectedFilter={selectedFilter}
+              onFilterChange={setSelectedFilter}
+            />
+          </div>
+
+          {/* Right Panel - Chat Conversation */}
+          <ChatConversation
             selectedChat={selectedChat}
-            onChatSelect={setSelectedChat}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            selectedFilter={selectedFilter}
-            onFilterChange={setSelectedFilter}
+            messages={currentMessages}
+            messageText={messageText}
+            onMessageChange={setMessageText}
+            onSendMessage={handleSendMessage}
+            onOpenActions={() => setIsActionDrawerOpen(true)}
+            hideHeader={true}
           />
         </div>
-
-        {/* Right Panel - Chat Conversation */}
-        <ChatConversation
-          selectedChat={selectedChat}
-          messages={currentMessages}
-          messageText={messageText}
-          onMessageChange={setMessageText}
-          onSendMessage={handleSendMessage}
-          onOpenActions={() => setIsActionDrawerOpen(true)}
-        />
       </div>
 
       {/* MOBILE/TABLET LAYOUT - Original Design with Task Cards & Filters */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2536,75 +2536,81 @@ const ChatContactsList: React.FC<{
     <div className="flex flex-col h-full bg-white border-r border-gray-200">
       {/* Header */}
       <div className="p-4 border-b border-gray-200">
-        {/* Top Row: Task Summary Cards */}
-        <div className="flex justify-end mb-4">
-          <div className="flex gap-3">
-            {taskSummaries.map((task) => (
-              <div
-                key={task.id}
-                className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow min-w-[120px]"
-              >
-                <div className="text-center">
-                  <div className="text-xl font-bold text-gray-900 mb-1">
-                    {task.count}
-                  </div>
-                  <div className="text-xs text-gray-600 leading-tight">
-                    {task.title}
-                  </div>
+        {/* Title and Action Buttons */}
+        <div className="flex items-center justify-between mb-3">
+          <h1 className="text-xl font-semibold text-gray-900">Chats</h1>
+          <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <MoreVertical className="h-4 w-4 text-gray-600" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-4" align="end">
+              {/* Filter Tabs */}
+              <div className="space-y-4">
+                <div className="flex gap-2 flex-wrap">
+                  {filterTabs.map((filter) => {
+                    const count = getFilterCount(filter);
+                    return (
+                      <button
+                        key={filter}
+                        onClick={() => {
+                          onFilterChange(filter);
+                          setIsPopoverOpen(false);
+                        }}
+                        className={cn(
+                          "px-4 py-2 rounded-full text-sm font-medium transition-colors flex items-center gap-2",
+                          selectedFilter === filter
+                            ? "bg-blue-500 text-white"
+                            : "bg-gray-100 text-gray-700 hover:bg-gray-200",
+                        )}
+                      >
+                        <span>{filter}</span>
+                        <Badge
+                          className={cn(
+                            "text-xs",
+                            selectedFilter === filter
+                              ? "bg-white/20 text-white"
+                              : "bg-blue-500 text-white",
+                          )}
+                        >
+                          {count}
+                        </Badge>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {/* Task Summary Cards */}
+                <div className="grid grid-cols-2 gap-3">
+                  {taskSummaries.map((task) => (
+                    <div
+                      key={task.id}
+                      className="bg-gray-100 rounded-2xl p-4 text-center cursor-pointer hover:bg-gray-200 transition-colors"
+                    >
+                      <div className="text-2xl font-bold text-blue-500 mb-1">
+                        {task.count}
+                      </div>
+                      <div className="text-xs font-medium text-gray-800 leading-tight">
+                        {task.title}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
-            ))}
-          </div>
+            </PopoverContent>
+          </Popover>
         </div>
 
-        {/* Main Row: Title, Search, and Filters */}
-        <div className="flex items-center gap-4">
-          {/* Chats Title */}
-          <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
-            Chats
-          </h1>
-
-          {/* Search Bar */}
-          <div className="relative flex-shrink-0 w-64">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search or start a new chat"
-              className="pl-10 bg-gray-50 border-gray-200 h-9"
-            />
-          </div>
-
-          {/* Filter Buttons */}
-          <div className="flex gap-2 flex-1">
-            {filterTabs.map((filter) => {
-              const count = getFilterCount(filter);
-              return (
-                <button
-                  key={filter}
-                  onClick={() => onFilterChange(filter)}
-                  className={cn(
-                    "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
-                    selectedFilter === filter
-                      ? "bg-blue-500 text-white"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200",
-                  )}
-                >
-                  <span>{filter}</span>
-                  <span
-                    className={cn(
-                      "text-xs font-semibold px-1.5 py-0.5 rounded-full",
-                      selectedFilter === filter
-                        ? "bg-white/20 text-white"
-                        : "bg-blue-500 text-white",
-                    )}
-                  >
-                    {count}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search or start a new chat"
+            className="pl-10 bg-gray-50 border-gray-200"
+          />
         </div>
       </div>
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2725,32 +2725,34 @@ const ChatConversation: React.FC<{
   return (
     <div className="flex-1 flex flex-col bg-white">
       {/* Chat Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
-        <Avatar className="h-10 w-10">
-          <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
-          <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-            {selectedChat.name
-              .split(" ")
-              .map((n) => n[0])
-              .join("")
-              .slice(0, 2)}
-          </AvatarFallback>
-        </Avatar>
+      {!hideHeader && (
+        <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
+            <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+              {selectedChat.name
+                .split(" ")
+                .map((n) => n[0])
+                .join("")
+                .slice(0, 2)}
+            </AvatarFallback>
+          </Avatar>
 
-        <div className="flex-1">
-          <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
-          <p className="text-sm text-gray-500">Online</p>
-        </div>
+          <div className="flex-1">
+            <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
+            <p className="text-sm text-gray-500">Online</p>
+          </div>
 
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <Phone className="h-4 w-4 text-gray-600" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <MoreHorizontal className="h-4 w-4 text-gray-600" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Phone className="h-4 w-4 text-gray-600" />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreHorizontal className="h-4 w-4 text-gray-600" />
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 bg-gray-50">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2693,6 +2693,7 @@ const ChatConversation: React.FC<{
   onMessageChange: (text: string) => void;
   onSendMessage: () => void;
   onOpenActions: () => void;
+  hideHeader?: boolean;
 }> = ({
   selectedChat,
   messages,
@@ -2700,6 +2701,7 @@ const ChatConversation: React.FC<{
   onMessageChange,
   onSendMessage,
   onOpenActions,
+  hideHeader = false,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2497,6 +2497,7 @@ const ChatContactsList: React.FC<{
   onSearchChange: (query: string) => void;
   selectedFilter: string;
   onFilterChange: (filter: string) => void;
+  hideHeader?: boolean;
 }> = ({
   chatItems,
   selectedChat,
@@ -2505,6 +2506,7 @@ const ChatContactsList: React.FC<{
   onSearchChange,
   selectedFilter,
   onFilterChange,
+  hideHeader = false,
 }) => {
   const filterTabs = ["All", "Unread", "Groups", "Labels", "Archived"];
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2688,6 +2688,7 @@ const ChatConversation: React.FC<{
   onMessageChange: (text: string) => void;
   onSendMessage: () => void;
   onOpenActions: () => void;
+  hideHeader?: boolean;
 }> = ({
   selectedChat,
   messages,
@@ -2695,6 +2696,7 @@ const ChatConversation: React.FC<{
   onMessageChange,
   onSendMessage,
   onOpenActions,
+  hideHeader = false,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2724,34 +2724,32 @@ const ChatConversation: React.FC<{
   return (
     <div className="flex-1 flex flex-col bg-white">
       {/* Chat Header */}
-      {!hideHeader && (
-        <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
-          <Avatar className="h-10 w-10">
-            <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
-            <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-              {selectedChat.name
-                .split(" ")
-                .map((n) => n[0])
-                .join("")
-                .slice(0, 2)}
-            </AvatarFallback>
-          </Avatar>
+      <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
+        <Avatar className="h-10 w-10">
+          <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
+          <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+            {selectedChat.name
+              .split(" ")
+              .map((n) => n[0])
+              .join("")
+              .slice(0, 2)}
+          </AvatarFallback>
+        </Avatar>
 
-          <div className="flex-1">
-            <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
-            <p className="text-sm text-gray-500">Online</p>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <Phone className="h-4 w-4 text-gray-600" />
-            </Button>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <MoreHorizontal className="h-4 w-4 text-gray-600" />
-            </Button>
-          </div>
+        <div className="flex-1">
+          <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
+          <p className="text-sm text-gray-500">Online</p>
         </div>
-      )}
+
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <Phone className="h-4 w-4 text-gray-600" />
+          </Button>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <MoreHorizontal className="h-4 w-4 text-gray-600" />
+          </Button>
+        </div>
+      </div>
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 bg-gray-50">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3514,7 +3514,7 @@ const Chats: React.FC = () => {
             </div>
 
             {/* Filter Buttons */}
-            <div className="flex gap-2 flex-1">
+            <div className="flex gap-1 flex-1">
               {filterTabs.map((filter) => {
                 const count = getFilterCount(filter);
                 return (
@@ -3522,7 +3522,7 @@ const Chats: React.FC = () => {
                     key={filter}
                     onClick={() => setSelectedFilter(filter)}
                     className={cn(
-                      "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
+                      "px-2 py-1 rounded-full text-xs font-medium transition-colors flex items-center gap-1 whitespace-nowrap",
                       selectedFilter === filter
                         ? "bg-blue-500 text-white"
                         : "bg-gray-100 text-gray-700 hover:bg-gray-200",
@@ -3531,7 +3531,7 @@ const Chats: React.FC = () => {
                     <span>{filter}</span>
                     <span
                       className={cn(
-                        "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                        "text-xs font-semibold px-1 py-0.5 rounded-full min-w-[18px] text-center",
                         selectedFilter === filter
                           ? "bg-white/20 text-white"
                           : "bg-blue-500 text-white",

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2536,81 +2536,75 @@ const ChatContactsList: React.FC<{
     <div className="flex flex-col h-full bg-white border-r border-gray-200">
       {/* Header */}
       <div className="p-4 border-b border-gray-200">
-        {/* Title and Action Buttons */}
-        <div className="flex items-center justify-between mb-3">
-          <h1 className="text-xl font-semibold text-gray-900">Chats</h1>
-          <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-            <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <MoreVertical className="h-4 w-4 text-gray-600" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-80 p-4" align="end">
-              {/* Filter Tabs */}
-              <div className="space-y-4">
-                <div className="flex gap-2 flex-wrap">
-                  {filterTabs.map((filter) => {
-                    const count = getFilterCount(filter);
-                    return (
-                      <button
-                        key={filter}
-                        onClick={() => {
-                          onFilterChange(filter);
-                          setIsPopoverOpen(false);
-                        }}
-                        className={cn(
-                          "px-4 py-2 rounded-full text-sm font-medium transition-colors flex items-center gap-2",
-                          selectedFilter === filter
-                            ? "bg-blue-500 text-white"
-                            : "bg-gray-100 text-gray-700 hover:bg-gray-200",
-                        )}
-                      >
-                        <span>{filter}</span>
-                        <Badge
-                          className={cn(
-                            "text-xs",
-                            selectedFilter === filter
-                              ? "bg-white/20 text-white"
-                              : "bg-blue-500 text-white",
-                          )}
-                        >
-                          {count}
-                        </Badge>
-                      </button>
-                    );
-                  })}
-                </div>
-
-                {/* Task Summary Cards */}
-                <div className="grid grid-cols-2 gap-3">
-                  {taskSummaries.map((task) => (
-                    <div
-                      key={task.id}
-                      className="bg-gray-100 rounded-2xl p-4 text-center cursor-pointer hover:bg-gray-200 transition-colors"
-                    >
-                      <div className="text-2xl font-bold text-blue-500 mb-1">
-                        {task.count}
-                      </div>
-                      <div className="text-xs font-medium text-gray-800 leading-tight">
-                        {task.title}
-                      </div>
-                    </div>
-                  ))}
+        {/* Top Row: Task Summary Cards */}
+        <div className="flex justify-end mb-4">
+          <div className="flex gap-3">
+            {taskSummaries.map((task) => (
+              <div
+                key={task.id}
+                className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow min-w-[120px]"
+              >
+                <div className="text-center">
+                  <div className="text-xl font-bold text-gray-900 mb-1">
+                    {task.count}
+                  </div>
+                  <div className="text-xs text-gray-600 leading-tight">
+                    {task.title}
+                  </div>
                 </div>
               </div>
-            </PopoverContent>
-          </Popover>
+            ))}
+          </div>
         </div>
 
-        {/* Search */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <Input
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Search or start a new chat"
-            className="pl-10 bg-gray-50 border-gray-200"
-          />
+        {/* Main Row: Title, Search, and Filters */}
+        <div className="flex items-center gap-4">
+          {/* Chats Title */}
+          <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
+            Chats
+          </h1>
+
+          {/* Search Bar */}
+          <div className="relative flex-shrink-0 w-64">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder="Search or start a new chat"
+              className="pl-10 bg-gray-50 border-gray-200 h-9"
+            />
+          </div>
+
+          {/* Filter Buttons */}
+          <div className="flex gap-2 flex-1">
+            {filterTabs.map((filter) => {
+              const count = getFilterCount(filter);
+              return (
+                <button
+                  key={filter}
+                  onClick={() => onFilterChange(filter)}
+                  className={cn(
+                    "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
+                    selectedFilter === filter
+                      ? "bg-blue-500 text-white"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200",
+                  )}
+                >
+                  <span>{filter}</span>
+                  <span
+                    className={cn(
+                      "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                      selectedFilter === filter
+                        ? "bg-white/20 text-white"
+                        : "bg-blue-500 text-white",
+                    )}
+                  >
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2537,79 +2537,81 @@ const ChatContactsList: React.FC<{
   return (
     <div className="flex flex-col h-full bg-white border-r border-gray-200">
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 bg-white">
-        {/* Task Summary Cards Row */}
-        <div className="flex justify-end mb-3">
-          <div className="flex gap-3">
-            {taskSummaries.map((task) => (
-              <div
-                key={task.id}
-                className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
-                style={{ minWidth: "70px" }}
-              >
-                <div className="text-center">
-                  <div className="text-lg font-bold text-gray-900 mb-1">
-                    {task.count}
-                  </div>
-                  <div className="text-xs text-gray-600 leading-tight">
-                    {task.title}
+      {!hideHeader && (
+        <div className="p-4 border-b border-gray-200 bg-white">
+          {/* Task Summary Cards Row */}
+          <div className="flex justify-end mb-3">
+            <div className="flex gap-3">
+              {taskSummaries.map((task) => (
+                <div
+                  key={task.id}
+                  className="bg-white rounded-lg p-3 shadow-sm border border-gray-100 cursor-pointer hover:shadow-md transition-shadow"
+                  style={{ minWidth: "70px" }}
+                >
+                  <div className="text-center">
+                    <div className="text-lg font-bold text-gray-900 mb-1">
+                      {task.count}
+                    </div>
+                    <div className="text-xs text-gray-600 leading-tight">
+                      {task.title}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Main Header Row: Title, Search, and Filters */}
-        <div className="flex items-center gap-4">
-          {/* Chats Title */}
-          <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
-            Chats
-          </h1>
-
-          {/* Search Bar */}
-          <div className="relative flex-shrink-0" style={{ width: "200px" }}>
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search or start a new chat"
-              className="pl-10 bg-gray-50 border-gray-200 h-9"
-            />
+              ))}
+            </div>
           </div>
 
-          {/* Filter Buttons */}
-          <div className="flex gap-2 flex-1">
-            {filterTabs.map((filter) => {
-              const count = getFilterCount(filter);
-              return (
-                <button
-                  key={filter}
-                  onClick={() => onFilterChange(filter)}
-                  className={cn(
-                    "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
-                    selectedFilter === filter
-                      ? "bg-blue-500 text-white"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200",
-                  )}
-                >
-                  <span>{filter}</span>
-                  <span
+          {/* Main Header Row: Title, Search, and Filters */}
+          <div className="flex items-center gap-4">
+            {/* Chats Title */}
+            <h1 className="text-xl font-semibold text-gray-900 flex-shrink-0">
+              Chats
+            </h1>
+
+            {/* Search Bar */}
+            <div className="relative flex-shrink-0" style={{ width: "200px" }}>
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                value={searchQuery}
+                onChange={(e) => onSearchChange(e.target.value)}
+                placeholder="Search or start a new chat"
+                className="pl-10 bg-gray-50 border-gray-200 h-9"
+              />
+            </div>
+
+            {/* Filter Buttons */}
+            <div className="flex gap-2 flex-1">
+              {filterTabs.map((filter) => {
+                const count = getFilterCount(filter);
+                return (
+                  <button
+                    key={filter}
+                    onClick={() => onFilterChange(filter)}
                     className={cn(
-                      "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                      "px-3 py-1.5 rounded-full text-sm font-medium transition-colors flex items-center gap-1.5 whitespace-nowrap",
                       selectedFilter === filter
-                        ? "bg-white/20 text-white"
-                        : "bg-blue-500 text-white",
+                        ? "bg-blue-500 text-white"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200",
                     )}
                   >
-                    {count}
-                  </span>
-                </button>
-              );
-            })}
+                    <span>{filter}</span>
+                    <span
+                      className={cn(
+                        "text-xs font-semibold px-1.5 py-0.5 rounded-full",
+                        selectedFilter === filter
+                          ? "bg-white/20 text-white"
+                          : "bg-blue-500 text-white",
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Chat List */}
       <div className="flex-1 overflow-y-auto">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2730,32 +2730,34 @@ const ChatConversation: React.FC<{
   return (
     <div className="flex-1 flex flex-col bg-white">
       {/* Chat Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
-        <Avatar className="h-10 w-10">
-          <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
-          <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-            {selectedChat.name
-              .split(" ")
-              .map((n) => n[0])
-              .join("")
-              .slice(0, 2)}
-          </AvatarFallback>
-        </Avatar>
+      {!hideHeader && (
+        <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
+            <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+              {selectedChat.name
+                .split(" ")
+                .map((n) => n[0])
+                .join("")
+                .slice(0, 2)}
+            </AvatarFallback>
+          </Avatar>
 
-        <div className="flex-1">
-          <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
-          <p className="text-sm text-gray-500">Online</p>
-        </div>
+          <div className="flex-1">
+            <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
+            <p className="text-sm text-gray-500">Online</p>
+          </div>
 
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <Phone className="h-4 w-4 text-gray-600" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <MoreHorizontal className="h-4 w-4 text-gray-600" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Phone className="h-4 w-4 text-gray-600" />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreHorizontal className="h-4 w-4 text-gray-600" />
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 bg-gray-50">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2497,6 +2497,7 @@ const ChatContactsList: React.FC<{
   onSearchChange: (query: string) => void;
   selectedFilter: string;
   onFilterChange: (filter: string) => void;
+  hideSearch?: boolean;
 }> = ({
   chatItems,
   selectedChat,
@@ -2505,6 +2506,7 @@ const ChatContactsList: React.FC<{
   onSearchChange,
   selectedFilter,
   onFilterChange,
+  hideSearch = false,
 }) => {
   const filterTabs = ["All", "Unread", "Groups", "Labels", "Archived"];
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2726,32 +2726,34 @@ const ChatConversation: React.FC<{
   return (
     <div className="flex-1 flex flex-col bg-white">
       {/* Chat Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
-        <Avatar className="h-10 w-10">
-          <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
-          <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-            {selectedChat.name
-              .split(" ")
-              .map((n) => n[0])
-              .join("")
-              .slice(0, 2)}
-          </AvatarFallback>
-        </Avatar>
+      {!hideHeader && (
+        <div className="flex items-center gap-3 p-4 border-b border-gray-200 bg-white">
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={selectedChat.avatar} alt={selectedChat.name} />
+            <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+              {selectedChat.name
+                .split(" ")
+                .map((n) => n[0])
+                .join("")
+                .slice(0, 2)}
+            </AvatarFallback>
+          </Avatar>
 
-        <div className="flex-1">
-          <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
-          <p className="text-sm text-gray-500">Online</p>
-        </div>
+          <div className="flex-1">
+            <h2 className="font-semibold text-gray-900">{selectedChat.name}</h2>
+            <p className="text-sm text-gray-500">Online</p>
+          </div>
 
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <Phone className="h-4 w-4 text-gray-600" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8">
-            <MoreHorizontal className="h-4 w-4 text-gray-600" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Phone className="h-4 w-4 text-gray-600" />
+            </Button>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreHorizontal className="h-4 w-4 text-gray-600" />
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 bg-gray-50">

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3440,31 +3440,87 @@ const Chats: React.FC = () => {
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}
       <div
-        className="hidden lg:flex h-full bg-white"
+        className="hidden lg:flex flex-col h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Left Panel - Chat Contacts */}
-        <div className="w-1/3 min-w-[300px] max-w-[400px]">
-          <ChatContactsList
-            chatItems={filteredChats}
+        {/* Full Width Header Section - Chat Title and Search */}
+        {selectedChat && (
+          <div className="w-full bg-white border-b border-gray-200">
+            {/* Chat Header - Full Width */}
+            <div className="flex items-center gap-3 p-4 bg-white">
+              <Avatar className="h-10 w-10">
+                <AvatarImage
+                  src={selectedChat.avatar}
+                  alt={selectedChat.name}
+                />
+                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
+                  {selectedChat.name
+                    .split(" ")
+                    .map((n) => n[0])
+                    .join("")
+                    .slice(0, 2)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="flex-1">
+                <h2 className="font-semibold text-gray-900">
+                  {selectedChat.name}
+                </h2>
+                <p className="text-sm text-gray-500">Online</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Phone className="h-4 w-4 text-gray-600" />
+                </Button>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
+                </Button>
+              </div>
+            </div>
+
+            {/* Full Width Search */}
+            <div className="px-4 pb-4">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search or start a new chat"
+                  className="w-full pl-10 bg-gray-50 border-gray-200"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Main Content Area */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left Panel - Chat Contacts */}
+          <div className="w-1/3 min-w-[300px] max-w-[400px]">
+            <ChatContactsList
+              chatItems={filteredChats}
+              selectedChat={selectedChat}
+              onChatSelect={setSelectedChat}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              selectedFilter={selectedFilter}
+              onFilterChange={setSelectedFilter}
+              hideSearch={true}
+            />
+          </div>
+
+          {/* Right Panel - Chat Conversation */}
+          <ChatConversation
             selectedChat={selectedChat}
-            onChatSelect={setSelectedChat}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            selectedFilter={selectedFilter}
-            onFilterChange={setSelectedFilter}
+            messages={currentMessages}
+            messageText={messageText}
+            onMessageChange={setMessageText}
+            onSendMessage={handleSendMessage}
+            onOpenActions={() => setIsActionDrawerOpen(true)}
+            hideHeader={true}
           />
         </div>
-
-        {/* Right Panel - Chat Conversation */}
-        <ChatConversation
-          selectedChat={selectedChat}
-          messages={currentMessages}
-          messageText={messageText}
-          onMessageChange={setMessageText}
-          onSendMessage={handleSendMessage}
-          onOpenActions={() => setIsActionDrawerOpen(true)}
-        />
       </div>
 
       {/* MOBILE/TABLET LAYOUT - Original Design with Task Cards & Filters */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3439,6 +3439,31 @@ const Chats: React.FC = () => {
     }
   });
 
+  // Define filter tabs and count function for the desktop layout
+  const filterTabs = ["All", "Unread", "Groups", "Labels", "Archived"];
+
+  const getFilterCount = (filter: string) => {
+    switch (filter) {
+      case "All":
+        return chatItems.filter((chat) => !chat.isArchived).length;
+      case "Unread":
+        return chatItems.filter(
+          (chat) => !chat.isArchived && chat.unreadCount > 0,
+        ).length;
+      case "Groups":
+        return chatItems.filter((chat) => !chat.isArchived && chat.isGroup)
+          .length;
+      case "Labels":
+        return chatItems.filter(
+          (chat) => !chat.isArchived && chat.tags && chat.tags.length > 0,
+        ).length;
+      case "Archived":
+        return chatItems.filter((chat) => chat.isArchived === true).length;
+      default:
+        return 0;
+    }
+  };
+
   return (
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2497,7 +2497,6 @@ const ChatContactsList: React.FC<{
   onSearchChange: (query: string) => void;
   selectedFilter: string;
   onFilterChange: (filter: string) => void;
-  hideSearch?: boolean;
 }> = ({
   chatItems,
   selectedChat,
@@ -2506,7 +2505,6 @@ const ChatContactsList: React.FC<{
   onSearchChange,
   selectedFilter,
   onFilterChange,
-  hideSearch = false,
 }) => {
   const filterTabs = ["All", "Unread", "Groups", "Labels", "Archived"];
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3444,72 +3444,31 @@ const Chats: React.FC = () => {
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}
       <div
-        className="hidden lg:flex flex-col h-full bg-white"
+        className="hidden lg:flex h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Full Width Chat Header - Only show when chat is selected */}
-        {selectedChat && (
-          <div className="w-full border-b border-gray-200 bg-white">
-            <div className="flex items-center gap-3 p-4">
-              <Avatar className="h-10 w-10">
-                <AvatarImage
-                  src={selectedChat.avatar}
-                  alt={selectedChat.name}
-                />
-                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-                  {selectedChat.name
-                    .split(" ")
-                    .map((n) => n[0])
-                    .join("")
-                    .slice(0, 2)}
-                </AvatarFallback>
-              </Avatar>
-
-              <div className="flex-1">
-                <h2 className="font-semibold text-gray-900">
-                  {selectedChat.name}
-                </h2>
-                <p className="text-sm text-gray-500">Online</p>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <Phone className="h-4 w-4 text-gray-600" />
-                </Button>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Main Content Area */}
-        <div className="flex flex-1 min-h-0">
-          {/* Left Panel - Chat Contacts */}
-          <div className="w-1/3 min-w-[300px] max-w-[400px]">
-            <ChatContactsList
-              chatItems={filteredChats}
-              selectedChat={selectedChat}
-              onChatSelect={setSelectedChat}
-              searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
-              selectedFilter={selectedFilter}
-              onFilterChange={setSelectedFilter}
-            />
-          </div>
-
-          {/* Right Panel - Chat Conversation */}
-          <ChatConversation
+        {/* Left Panel - Chat Contacts */}
+        <div className="w-1/3 min-w-[300px] max-w-[400px]">
+          <ChatContactsList
+            chatItems={filteredChats}
             selectedChat={selectedChat}
-            messages={currentMessages}
-            messageText={messageText}
-            onMessageChange={setMessageText}
-            onSendMessage={handleSendMessage}
-            onOpenActions={() => setIsActionDrawerOpen(true)}
-            hideHeader={true}
+            onChatSelect={setSelectedChat}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            selectedFilter={selectedFilter}
+            onFilterChange={setSelectedFilter}
           />
         </div>
+
+        {/* Right Panel - Chat Conversation */}
+        <ChatConversation
+          selectedChat={selectedChat}
+          messages={currentMessages}
+          messageText={messageText}
+          onMessageChange={setMessageText}
+          onSendMessage={handleSendMessage}
+          onOpenActions={() => setIsActionDrawerOpen(true)}
+        />
       </div>
 
       {/* MOBILE/TABLET LAYOUT - Original Design with Task Cards & Filters */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3448,87 +3448,31 @@ const Chats: React.FC = () => {
     <>
       {/* DESKTOP LAYOUT - WhatsApp Style (Only for large screens 1024px+) */}
       <div
-        className="hidden lg:flex flex-col h-full bg-white"
+        className="hidden lg:flex h-full bg-white"
         style={{ height: "calc(100vh - 86px)" }}
       >
-        {/* Full Width Header Section - Chat Title and Search */}
-        {selectedChat && (
-          <div className="w-full bg-white border-b border-gray-200">
-            {/* Chat Header - Full Width */}
-            <div className="flex items-center gap-3 p-4 bg-white">
-              <Avatar className="h-10 w-10">
-                <AvatarImage
-                  src={selectedChat.avatar}
-                  alt={selectedChat.name}
-                />
-                <AvatarFallback className="bg-gray-300 text-gray-700 text-sm">
-                  {selectedChat.name
-                    .split(" ")
-                    .map((n) => n[0])
-                    .join("")
-                    .slice(0, 2)}
-                </AvatarFallback>
-              </Avatar>
-
-              <div className="flex-1">
-                <h2 className="font-semibold text-gray-900">
-                  {selectedChat.name}
-                </h2>
-                <p className="text-sm text-gray-500">Online</p>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <Phone className="h-4 w-4 text-gray-600" />
-                </Button>
-                <Button variant="ghost" size="icon" className="h-8 w-8">
-                  <MoreHorizontal className="h-4 w-4 text-gray-600" />
-                </Button>
-              </div>
-            </div>
-
-            {/* Full Width Search */}
-            <div className="px-4 pb-4">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                <Input
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search or start a new chat"
-                  className="w-full pl-10 bg-gray-50 border-gray-200"
-                />
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Main Content Area */}
-        <div className="flex flex-1 min-h-0">
-          {/* Left Panel - Chat Contacts */}
-          <div className="w-1/3 min-w-[300px] max-w-[400px]">
-            <ChatContactsList
-              chatItems={filteredChats}
-              selectedChat={selectedChat}
-              onChatSelect={setSelectedChat}
-              searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
-              selectedFilter={selectedFilter}
-              onFilterChange={setSelectedFilter}
-              hideSearch={true}
-            />
-          </div>
-
-          {/* Right Panel - Chat Conversation */}
-          <ChatConversation
+        {/* Left Panel - Chat Contacts */}
+        <div className="w-1/3 min-w-[300px] max-w-[400px]">
+          <ChatContactsList
+            chatItems={filteredChats}
             selectedChat={selectedChat}
-            messages={currentMessages}
-            messageText={messageText}
-            onMessageChange={setMessageText}
-            onSendMessage={handleSendMessage}
-            onOpenActions={() => setIsActionDrawerOpen(true)}
-            hideHeader={true}
+            onChatSelect={setSelectedChat}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            selectedFilter={selectedFilter}
+            onFilterChange={setSelectedFilter}
           />
         </div>
+
+        {/* Right Panel - Chat Conversation */}
+        <ChatConversation
+          selectedChat={selectedChat}
+          messages={currentMessages}
+          messageText={messageText}
+          onMessageChange={setMessageText}
+          onSendMessage={handleSendMessage}
+          onOpenActions={() => setIsActionDrawerOpen(true)}
+        />
       </div>
 
       {/* MOBILE/TABLET LAYOUT - Original Design with Task Cards & Filters */}

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -2689,6 +2689,7 @@ const ChatConversation: React.FC<{
   onMessageChange: (text: string) => void;
   onSendMessage: () => void;
   onOpenActions: () => void;
+  hideHeader?: boolean;
 }> = ({
   selectedChat,
   messages,
@@ -2696,6 +2697,7 @@ const ChatConversation: React.FC<{
   onMessageChange,
   onSendMessage,
   onOpenActions,
+  hideHeader = false,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
This change adds a hideHeader prop to both ChatContactsList and ChatConversation components and redesigns the desktop chat layout.

Changes made:
- Added optional hideHeader prop to ChatContactsList and ChatConversation components
- Wrapped header sections in conditional rendering based on hideHeader prop
- Redesigned desktop layout to move all controls to a single full-width header section
- Moved task summary cards, search bar, and filter buttons to the top-level header
- Updated filter button styling to be more compact for the new layout
- Adjusted component structure to use hideHeader=true for desktop layout components
- Modified search bar width and filter button sizes for better space utilization

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

🔗 [Edit in Builder.io](https://builder.io/app/projects/092a44f38d78473c860592dad47cd263/cosmos-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>092a44f38d78473c860592dad47cd263</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->