### PR TITLE
Add employee chat navigation from Overview to Chats

### DIFF
--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3350,6 +3350,9 @@ const CompanyActionDrawer: React.FC<{
 // ============================================================
 
 const Chats: React.FC = () => {
+  // Hooks
+  const location = useLocation();
+
   // For mobile: start with no chat selected (show list)
   // For desktop: start with first chat selected (show conversation)
   const [selectedChat, setSelectedChat] = useState<ChatItem | null>(null);

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -3366,6 +3366,44 @@ const Chats: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFilter, setSelectedFilter] = useState("All");
 
+  // Handle employee chat from navigation state
+  useEffect(() => {
+    const state = location.state as any;
+    if (state?.openChatWithEmployee) {
+      const employeeChat = state.openChatWithEmployee;
+
+      // Check if chat already exists in chatItems
+      const existingChat = chatItems.find(
+        (chat) => chat.id === employeeChat.id,
+      );
+
+      if (existingChat) {
+        // If chat exists, select it
+        setSelectedChat(existingChat);
+      } else {
+        // If chat doesn't exist, create a new chat item and add it to the list
+        const newEmployeeChat: ChatItem = {
+          ...employeeChat,
+          // Ensure all required fields are present
+          isArchived: false,
+        };
+
+        // Add to chat items (you might want to persist this)
+        chatItems.unshift(newEmployeeChat);
+        setSelectedChat(newEmployeeChat);
+
+        // Initialize empty conversation for this new chat
+        setChatConversations((prev) => ({
+          ...prev,
+          [newEmployeeChat.id]: [],
+        }));
+      }
+
+      // Clear the navigation state to prevent re-triggering
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
+
   // Set default chat for desktop on mount
   useEffect(() => {
     const setDefaultChatForDesktop = () => {

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -2557,6 +2557,33 @@ const Overview: React.FC = () => {
     setModalView("attendance");
   };
 
+  // Handle contact employee
+  const handleContactEmployee = (employee: EmployeeAttendanceData) => {
+    // Close the modal first
+    setIsModalOpen(false);
+    setModalView("attendance");
+
+    // Navigate to chat page with employee data
+    navigate("/chats", {
+      state: {
+        openChatWithEmployee: {
+          id: `employee-${employee.id}`,
+          name: employee.name,
+          avatar: "", // Could be generated or stored elsewhere
+          lastMessage: "Start a new conversation",
+          timestamp: new Date().toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          }),
+          unreadCount: 0,
+          isGroup: false,
+          phone: `+91 ${Math.floor(Math.random() * 9000000000) + 1000000000}`,
+          tags: [employee.designation],
+        },
+      },
+    });
+  };
+
   return (
     <div className={cn("w-full p-3 sm:p-4 lg:p-6 font-inter")}>
       {/* Page Area */}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -2481,6 +2481,9 @@ const FullProfile: React.FC<FullProfileProps> = ({ employee, onBack }) => {
 };
 
 const Overview: React.FC = () => {
+  // Hooks
+  const navigate = useNavigate();
+
   // State Management
   const [selectedDateRange, setSelectedDateRange] =
     useState<DateRangeOption>("CUSTOM_RANGE");

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import {
   BarChart,

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -2038,7 +2038,7 @@ const FullProfile: React.FC<FullProfileProps> = ({ employee, onBack }) => {
                 d="M15 19l-7-7 7-7"
               />
             </svg>
-            back to attendance log
+            Back to attendance log
           </button>
           <h2 className="text-lg font-bold text-gray-900 absolute left-1/2 transform -translate-x-1/2">
             Profile

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -2537,6 +2537,16 @@ const Overview: React.FC = () => {
   // Handle view switching
   const handleViewFullProfile = () => {
     setModalView("profile");
+    // Scroll to top of modal content when switching to profile view
+    setTimeout(() => {
+      const modalContent =
+        document.querySelector("[data-radix-scroll-area-viewport]") ||
+        document.querySelector(".max-w-4xl.max-h-\\[90vh\\].overflow-y-auto") ||
+        document.querySelector('[role="dialog"] > div');
+      if (modalContent) {
+        modalContent.scrollTop = 0;
+      }
+    }, 0);
   };
 
   const handleBackToAttendance = () => {

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -3306,7 +3306,10 @@ const Overview: React.FC = () => {
                     >
                       View Full Profile
                     </button>
-                    <button className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors">
+                    <button
+                      onClick={() => handleContactEmployee(selectedEmployee)}
+                      className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
+                    >
                       Contact Employee
                     </button>
                   </div>


### PR DESCRIPTION
This change implements navigation from the Overview page to the Chats page with employee context.

Changes made:
- Added useLocation hook import to Chats.tsx
- Added useNavigate hook import to Overview.tsx
- Implemented useEffect in Chats component to handle employee chat from navigation state
- Added logic to check for existing chats or create new employee chat items
- Added handleContactEmployee function in Overview component
- Connected "Contact Employee" button to navigate to chats with employee data
- Added modal scroll-to-top functionality when switching to profile view
- Fixed capitalization of "Back to attendance log" text

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 67`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4ed8fb0089094fc6967ea8dccc2bd313/spark-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4ed8fb0089094fc6967ea8dccc2bd313</projectId>-->
<!--<branchName>spark-hub</branchName>-->