### PR TITLE
Add branch selector to holiday list with dynamic data

### DIFF
--- a/src/pages/EmployeeDashboard.tsx
+++ b/src/pages/EmployeeDashboard.tsx
@@ -3579,25 +3579,33 @@ export default function EmployeeDashboard() {
           {/* Statistics Cards */}
           <div className="grid grid-cols-4 gap-3 p-4 bg-gray-50">
             <div className="bg-white rounded-lg p-3 text-center border-b-2 border-blue-500 shadow-md">
-              <div className="text-2xl font-bold text-gray-900">17</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {currentBranchData.stats.total}
+              </div>
               <div className="text-xs font-medium text-gray-600 uppercase">
                 TOTAL
               </div>
             </div>
             <div className="bg-white rounded-lg p-3 text-center border-b-2 border-blue-500 shadow-md">
-              <div className="text-2xl font-bold text-gray-900">12</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {currentBranchData.stats.public}
+              </div>
               <div className="text-xs font-medium text-gray-600 uppercase">
                 PUBLIC
               </div>
             </div>
             <div className="bg-white rounded-lg p-3 text-center border-b-2 border-blue-500 shadow-md">
-              <div className="text-2xl font-bold text-gray-900">1</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {currentBranchData.stats.company}
+              </div>
               <div className="text-xs font-medium text-gray-600 uppercase">
                 COMPANY
               </div>
             </div>
             <div className="bg-white rounded-lg p-3 text-center border-b-2 border-blue-500 shadow-md">
-              <div className="text-2xl font-bold text-gray-900">0</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {currentBranchData.stats.regional}
+              </div>
               <div className="text-xs font-medium text-gray-600 uppercase">
                 REGIONAL
               </div>


### PR DESCRIPTION
This change adds a dropdown menu to the holiday list section that allows users to select different branches and view branch-specific holiday data.

Changes made:
- Added dropdown menu component imports
- Added selectedBranch state variable with default value "Head Office"
- Added getBranchHolidayData function with holiday data for three branches: "All Branches", "Head Office", and "Second Branch"
- Replaced static branch button with interactive DropdownMenu component
- Added three dropdown menu items for branch selection with icons and descriptions
- Updated statistics cards to display dynamic values based on selected branch
- Changed "Holiday list" title to "Holiday List" for consistency

The dropdown menu includes detailed branch information with addresses and allows switching between different holiday calendars for each location.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 79`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a4d40b854518486b86f2478be241be72/zen-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a4d40b854518486b86f2478be241be72</projectId>-->
<!--<branchName>zen-realm</branchName>-->